### PR TITLE
Spiders to airtable syncing workflow

### DIFF
--- a/.github/workflows/parse-spiders.yml
+++ b/.github/workflows/parse-spiders.yml
@@ -1,0 +1,11 @@
+name: Parse spiders
+ 
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+    paths:
+      - 'city_scrapers/spiders/**.py'
+ 
+jobs:
+  parse:
+    uses: City-Bureau/city-scrapers-core/.github/workflows/parse-spiders.yml@main

--- a/.github/workflows/sync-airtable.yml
+++ b/.github/workflows/sync-airtable.yml
@@ -1,0 +1,19 @@
+name: Sync spiders to Airtable
+ 
+on:
+  workflow_run:
+    workflows: ['Parse spiders']
+    types: [completed]
+ 
+jobs:
+  sync:
+    # Only run if the "parse-spiders.yml" (consumer) workflow succeeded.
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
+    uses: City-Bureau/city-scrapers-core/.github/workflows/sync-airtable.yml@main
+    with:
+      parse-run-id: ${{ github.event.workflow_run.id }}
+      CS_AIRTABLE_BASE_ID: ${{ vars.CS_AIRTABLE_BASE_ID }}
+      CS_SLUGS_TABLE_ID: ${{ vars.CS_SLUGS_TABLE_ID }}
+      CS_BACKLOG_TABLE_ID: ${{ vars.CS_BACKLOG_TABLE_ID }}
+    secrets:
+      CS_AIRTABLE_PAT: ${{ secrets.CS_AIRTABLE_PAT }}


### PR DESCRIPTION
## What does this PR do?
This PR adds two consumer stub yml files which will make calls to the reusable airtable sync workflow coming from `city-scrapers-core/`.

## Steps to test
Because the consumer stub needs to exist on the branch that include this PR, open PRs in any repo won't pick up the workflow until they're updated with the latest `main`. After merging:

- Update any open PR that adds or modifies a scraper with the latest main branch.
- The workflow will run automatically on the PR.
- Confirm that the spider name[s] and agency[ies] from the changed spider file[s] appear in the corresponding Airtable table.