### PR TITLE
Add staging workflow and settings

### DIFF
--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -1,0 +1,87 @@
+name: Staging
+
+on:
+  schedule:
+    - cron: "30 5 * * *"
+  push:
+    branches:
+      - staging
+  workflow_dispatch:
+
+env:
+  CI: true
+  PYTHON_VERSION: 3.11
+  PIPENV_VENV_IN_PROJECT: true
+  CITY_SCRAPERS_ENV: staging
+  SCRAPY_SETTINGS_MODULE: city_scrapers.settings.staging
+  AUTOTHROTTLE_MAX_DELAY: 30.0
+  AUTOTHROTTLE_START_DELAY: 1.5
+  AUTOTHROTTLE_TARGET_CONCURRENCY: 3.0
+  AZURE_ACCOUNT_KEY: ${{ secrets.AZURE_ACCOUNT_KEY }}
+  AZURE_ACCOUNT_NAME: ${{ secrets.AZURE_ACCOUNT_NAME }}
+  AZURE_STAGING_CONTAINER: ${{ secrets.AZURE_STAGING_CONTAINER }}
+  SENTRY_DSN: ${{ secrets.SENTRY_DSN }}
+
+jobs:
+  crawl:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: staging
+
+      - name: Set up Python ${{ env.PYTHON_VERSION }}
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ env.PYTHON_VERSION }}
+
+      - name: Install Pipenv
+        run: |
+          python -m pip install --upgrade pip
+          pip install pipenv
+
+      - name: Cache Python dependencies
+        uses: actions/cache@v4
+        with:
+          path: .venv
+          key: ${{ env.PYTHON_VERSION }}-${{ hashFiles('**/Pipfile.lock') }}
+          restore-keys: |
+            ${{ env.PYTHON_VERSION }}-
+            pip-
+
+      - name: Check and conditionally remove invalid virtual environment
+        run: |
+          if [ -d ".venv" ] && [ ! -f ".venv/bin/python" ]; then
+            echo "Virtual environment exists but Python executable is missing. Rebuilding."
+            rm -rf .venv
+          elif ! .venv/bin/python --version 2>&1 | grep -q "Python ${{ env.PYTHON_VERSION }}"; then
+            echo "Virtual environment Python version mismatch. Rebuilding."
+            rm -rf .venv
+          elif [ ! -d ".venv" ]; then
+            echo "No virtual environment found. Will build new one."
+          else
+            echo "Virtual environment appears valid. Reusing."
+          fi
+
+      - name: Install dependencies
+        run: pipenv sync
+        env:
+          PIPENV_DEFAULT_PYTHON_VERSION: ${{ env.PYTHON_VERSION }}
+
+      - name: Run scrapers
+        run: |
+          export PYTHONPATH=$(pwd):$PYTHONPATH
+          ./.deploy.sh
+
+      - name: Combine output feeds
+        run: |
+          export PYTHONPATH=$(pwd):$PYTHONPATH
+          pipenv run scrapy combinefeeds -s LOG_ENABLED=False
+
+  workflow-keepalive:
+    if: github.event_name == 'schedule'
+    runs-on: ubuntu-latest
+    permissions:
+      actions: write
+    steps:
+      - uses: liskin/gh-workflow-keepalive@v1

--- a/city_scrapers/settings/staging.py
+++ b/city_scrapers/settings/staging.py
@@ -1,0 +1,42 @@
+import os
+
+from .base import *  # noqa
+
+USER_AGENT = "City Scrapers [staging mode]. Learn more and say hello at https://citybureau.org/city-scrapers"  # noqa
+
+ITEM_PIPELINES = {
+    "city_scrapers_core.pipelines.AzureDiffPipeline": 200,
+    "city_scrapers_core.pipelines.MeetingPipeline": 300,
+    "city_scrapers_core.pipelines.OpenCivicDataPipeline": 400,
+}
+
+SENTRY_DSN = os.getenv("SENTRY_DSN")
+
+EXTENSIONS = {
+    "scrapy_sentry_errors.extensions.Errors": 10,
+    "scrapy.extensions.closespider.CloseSpider": None,
+}
+
+FEED_EXPORTERS = {
+    "json": "scrapy.exporters.JsonItemExporter",
+    "jsonlines": "scrapy.exporters.JsonLinesItemExporter",
+}
+
+FEED_FORMAT = "jsonlines"
+
+FEED_STORAGES = {
+    "azure": "city_scrapers_core.extensions.AzureBlobFeedStorage",
+}
+
+AZURE_ACCOUNT_NAME = os.getenv("AZURE_ACCOUNT_NAME")
+AZURE_ACCOUNT_KEY = os.getenv("AZURE_ACCOUNT_KEY")
+AZURE_CONTAINER = os.getenv("AZURE_STAGING_CONTAINER")
+
+FEED_URI = (
+    "azure://{account_name}:{account_key}@{container}"
+    "/%(year)s/%(month)s/%(day)s/%(hour_min)s/%(name)s.json"
+).format(
+    account_name=AZURE_ACCOUNT_NAME,
+    account_key=AZURE_ACCOUNT_KEY,
+    container=AZURE_CONTAINER,
+)


### PR DESCRIPTION
## Summary
- Add `city_scrapers/settings/staging.py` Scrapy settings module that writes feeds to `AZURE_STAGING_CONTAINER` and uses a staging-mode User-Agent.
- Add `.github/workflows/staging.yml` GitHub Actions workflow that crawls from the `staging` branch on a daily cron (05:30 UTC), on push to `staging`, and on manual dispatch.
- Mirrors the minimal pattern used by `city-scrapers-coloh` (no Playwright, no refresh-staging).

## Test plan
- [ ] Create `staging` branch in this repo so `actions/checkout@v4 ref: staging` resolves.
- [ ] Confirm GitHub Actions secret `AZURE_STAGING_CONTAINER` is set (value: `meetings-feed-oma-stg`).
- [ ] Confirm Azure container `meetings-feed-oma-stg` exists in the storage account.
- [ ] Trigger workflow via `workflow_dispatch` and verify feeds land in the staging container.

🤖 Generated with [Claude Code](https://claude.com/claude-code)