### PR TITLE
Pin scrapy to 2.11.2 (fix Scrapy 2.16 feed_options crash)

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -4,7 +4,7 @@ verify_ssl = true
 name = "pypi"
 
 [packages]
-scrapy = "*"
+scrapy = "==2.11.2"
 scrapy-sentry-errors = "1.0.0"
 city-scrapers-core = {ref = "main", git = "https://github.com/City-Bureau/city-scrapers-core.git", extras = ["azure"]}
 scrapy-wayback-middleware = "*"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "0faa3d04307dc86473007313e97cf7c186402198f29649f0aee78c9ad1c99df1"
+            "sha256": "9e51cc01be3d6f2f3db4a5f1ef44d58ea0282bb20c91747ec7056f759b620422"
         },
         "pipfile-spec": 6,
         "requires": {


### PR DESCRIPTION
The staging crawl fails with `TypeError: AzureBlobFeedStorage.__init__() got an unexpected keyword argument 'feed_options'` — Scrapy 2.16 passes `feed_options` to the storage backend, which `city_scrapers_core` doesn't accept.

Pin `scrapy = "==2.11.2"` (the family's known-good version) and update the lock meta-hash. **Surgical: only scrapy is pinned; no other dependency versions change** (main's lock already had scrapy 2.11.2; staging had floated to 2.16.0).

Local: `pipenv verify` → lock up-to-date. Full env test deferred to CI / the refresh-staging crawl re-run.